### PR TITLE
Actualize `nodejs` version in CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -14,6 +14,8 @@ jobs:
         gem install bundler
         bundle install --jobs 4 --retry 3
     - uses: actions/setup-node@v1
+      with:
+        node-version: '16'
     - name: Check markdown files using `markdownlint`
       run: |
         npm install -g markdownlint-cli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* Actualize `nodejs` version in CI
+
 ## 1.0.0 (2022-01-28)
 
 ### New Features


### PR DESCRIPTION
By default nodejs-10 is installed and it's
incompatible with latest `markdownlint-cli`